### PR TITLE
Model foreground for 3D data

### DIFF
--- a/src/tools21cm/foreground_model.py
+++ b/src/tools21cm/foreground_model.py
@@ -9,7 +9,7 @@ from . import cosmology as cm
 from . import const
 from . import conv
 
-def galactic_synch_fg(z, ncells, boxsize, max_baseline=2.):
+def galactic_synch_fg(z, ncells, boxsize, rseed=False):
 	"""
 	@ Ghara et al. (2017)
 
@@ -21,26 +21,34 @@ def galactic_synch_fg(z, ncells, boxsize, max_baseline=2.):
 		Number of cells on each axis.
 	boxsize     : float
 		Size of the FOV in Mpc.
-	max_baseline: float
-		Maximum baseline of the radio telescope in km (Default: 2).
+	rseed: int
+		random seed to have the same realisation (Default: False).
 	Returns
 	-------
 	A 2D numpy array of brightness temperature in mK.
 	"""
+	if(isinstance(z, float)):
+		z = np.array([z])
+	else:
+		z = np.array(z, copy=False)
+	gf_data = np.zeros((ncells, ncells, z.size))
+
+	if(rseed): np.random.seed(rseed)
 	X  = np.random.normal(size=(ncells, ncells))
 	Y  = np.random.normal(size=(ncells, ncells))
-	nu = cm.z_to_nu(z)
 	nu_s,A150,beta_,a_syn,Da_syn = 150,513,2.34,2.8,0.1
-	#c_light, m2Mpc = 3e8, 3.24e-23
-	#lam   = c_light/(nu*1e6)/1000.
-	U_cb  = (np.mgrid[-ncells/2:ncells/2,-ncells/2:ncells/2]+0.5)*cm.z_to_cdist(z)/boxsize
-	l_cb  = 2*np.pi*np.sqrt(U_cb[0,:,:]**2+U_cb[1,:,:]**2)
-	C_syn = A150*(1000/l_cb)**beta_*(nu/nu_s)**(-2*a_syn-2*Da_syn*np.log(nu/nu_s))
-	solid_angle = boxsize**2/cm.z_to_cdist(z)**2
-	AA = np.sqrt(solid_angle*C_syn/2)
-	T_four = AA*(X+Y*1j)
-	T_real = np.abs(np.fft.ifft2(T_four))   #in Jansky
-	return jansky_2_kelvin(T_real*1e6, z, boxsize=boxsize, ncells=ncells)
+
+	for i in range(0, z.size):
+		nu = cm.z_to_nu(z[i])
+		U_cb  = (np.mgrid[-ncells/2:ncells/2,-ncells/2:ncells/2]+0.5)*cm.z_to_cdist(z[i])/boxsize
+		l_cb  = 2*np.pi*np.sqrt(U_cb[0,:,:]**2+U_cb[1,:,:]**2)
+		C_syn = A150*(1000/l_cb)**beta_*(nu/nu_s)**(-2*a_syn-2*Da_syn*np.log(nu/nu_s))
+		solid_angle = boxsize**2/cm.z_to_cdist(z[i])**2
+		AA = np.sqrt(solid_angle*C_syn/2)
+		T_four = AA*(X+Y*1j)
+		T_real = np.abs(np.fft.ifft2(T_four))   #in Jansky
+		gf_data[..., i] = jansky_2_kelvin(T_real*1e6, z[i], boxsize=boxsize, ncells=ncells)
+	return gf_data.squeeze()
 
 def extragalactic_pointsource_fg(z, ncells, boxsize, S_max=100):
 	"""
@@ -61,19 +69,30 @@ def extragalactic_pointsource_fg(z, ncells, boxsize, S_max=100):
 	-------
 	A 2D numpy array of brightness temperature in mK.
 	"""
-	nu = cm.z_to_nu(z)
-	fg = np.zeros((ncells,ncells))
+	if(isinstance(z, float)):
+		z = np.array([z])
+	else:
+		z = np.array(z, copy=False)
+	exgf_data = np.zeros((ncells, ncells, z.size))
+
 	dS = 0.01
 	Ss = np.arange(0.1, S_max, dS)
-	solid_angle = boxsize**2/cm.z_to_cdist(z)**2
-	N  = int(10**3.75*np.trapz(Ss**(-1.6), x=Ss, dx=dS)*solid_angle)
-	x,y = np.random.random_integers(0, high=ncells-1, size=(2,N))
-	alpha_ps = 0.7+0.1*np.random.random(size=N)
-	S_s  = np.random.choice(Ss, N)
 	nu_s = 150
-	S_nu = S_s*(nu/nu_s)**(-alpha_ps)
-	for p in range(S_nu.size): fg[x[p],y[p]] = S_nu[p]
-	return jansky_2_kelvin(fg, z, boxsize=boxsize, ncells=ncells)
+	
+	for i in range(0, z.size):
+		nu = cm.z_to_nu(z[i])
+		fg = np.zeros((ncells, ncells))
+		solid_angle = boxsize**2/cm.z_to_cdist(z[i])**2
+		N  = int(10**3.75*np.trapz(Ss**(-1.6), x=Ss, dx=dS)*solid_angle)
+		x, y = np.random.random_integers(0, high=ncells-1, size=(2,N))
+		alpha_ps = 0.7+0.1*np.random.random(size=N)
+		S_s  = np.random.choice(Ss, N)
+		S_nu = S_s*(nu/nu_s)**(-alpha_ps)
+		for p in range(S_nu.size):
+			fg[x[p],y[p]] = S_nu[p]
+		exgf_data[...,i] = jansky_2_kelvin(fg, z[i], boxsize=boxsize, ncells=ncells)
+	return exgf_data.squeeze()
+
 
 def diabolo_filter(z, ncells=None, array=None, boxsize=None, mu=0.5, funct='step', small_base=40):
 	assert funct in ['step', 'sigmoid', 'gaussian']


### PR DESCRIPTION
Modified the foreground_model.py script so that now can automatically calculate galactic and extra-galactic foreground models for a cube or lightcone (3D data) and not only images (2D data). 
Based on the redshift provided, if a list, it assumes that the third dimension is the frequency axis, otherwise it works as always